### PR TITLE
Fixed non-ANSI code

### DIFF
--- a/dev/html.lisp
+++ b/dev/html.lisp
@@ -355,7 +355,6 @@
 ;	       (print (list :di level (first chunks))) 
 	       (loop for rest = chunks then (rest rest) 
 		  for chunk = (first rest) then (first rest)
-;		  while chunk ; This is not valid ANSI code
 		  for new-level = (and chunk (level chunk))
 		  while chunk
 		  when (= level new-level) do

--- a/dev/html.lisp
+++ b/dev/html.lisp
@@ -354,9 +354,10 @@
 	     (do-it (chunks level)
 ;	       (print (list :di level (first chunks))) 
 	       (loop for rest = chunks then (rest rest) 
-		  for chunk = (first rest) then (first rest) 
-		  while chunk 
-		  for new-level = (level chunk)
+		  for chunk = (first rest) then (first rest)
+;		  while chunk ; This is not valid ANSI code
+		  for new-level = (and chunk (level chunk))
+		  while chunk
 		  when (= level new-level) do
 		  (let ((index (inner-block rest))
 			(inner-markup (html-inner-block-markup chunk)))

--- a/dev/plain.lisp
+++ b/dev/plain.lisp
@@ -30,8 +30,8 @@ Eta" :format :plain)
 	     (do-it (chunks level)
 	       (loop for rest = chunks then (rest rest) 
 		  for chunk = (first rest) then (first rest) 
+		  for new-level = (and chunk (level chunk))
 		  while chunk 
-		  for new-level = (level chunk)
 		  when (= level new-level) do
 		  (let ((index (inner-block rest))
 			(inner-markup (html-inner-block-markup chunk)))


### PR DESCRIPTION
In LOOP statements, a WHILE cannot appear before a FOR statement. This is not valid ANSI code, as per the specification http://www.lispworks.com/documentation/HyperSpec/Body/m_loop.htm Indeed, ECL does not support this.
